### PR TITLE
Add row action icons and handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,13 @@
 
   <template id="rowTemplate">
     <tr>
-      <td class="px-3 py-2 align-top"><input type="checkbox" aria-label="Selectează rând" class="focusable w-4 h-4" /></td>
+      <td class="px-3 py-2 align-top">
+        <div class="flex items-center gap-1">
+          <input type="checkbox" aria-label="Selectează rând" class="focusable w-4 h-4" />
+          <button type="button" aria-label="Duplică rând" class="duplicate-row focusable text-blue-600">📄</button>
+          <button type="button" aria-label="Șterge rând" class="delete-row focusable text-rose-600">🗑</button>
+        </div>
+      </td>
       <td class="px-3 py-2 align-top"><input type="date" class="focusable block w-40 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" /></td>
       <td class="px-3 py-2 align-top"><input type="time" step="60" class="focusable block w-28 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" /></td>
       <td class="px-3 py-2 align-top">
@@ -375,6 +381,8 @@
         const node = els.rowTmpl.content.cloneNode(true);
         const [chk, date, start, end, breakMin, notes, out] = node.querySelectorAll("input, textarea, output");
         const nextDay = node.querySelector("input.next-day-toggle");
+        const delBtn = node.querySelector(".delete-row");
+        const dupBtn = node.querySelector(".duplicate-row");
 
         if (data) {
           date.value = data.date || ""; start.value = data.start || ""; end.value = data.end || "";
@@ -392,6 +400,27 @@
         [date, start, end, breakMin, notes, nextDay].forEach(el => el && el.addEventListener("input", recalc));
         recalc();
         const tr = node.querySelector("tr");
+
+        delBtn && delBtn.addEventListener("click", () => {
+          tr.remove();
+          if (!els.tableBody.querySelector("tr")) addRowUI({});
+          computeGrand();
+          save();
+        });
+
+        dupBtn && dupBtn.addEventListener("click", () => {
+          const rowData = {
+            date: date.value,
+            start: start.value,
+            end: end.value,
+            breakMin: Number(breakMin.value) || 0,
+            notes: notes.value,
+            nextDay: nextDay && nextDay.checked
+          };
+          addRowUI(rowData);
+          save();
+        });
+
         tr.classList.add("fade-in");
         els.tableBody.appendChild(node);
       }


### PR DESCRIPTION
## Summary
- add delete and duplicate buttons to row template
- wire up new buttons in addRowUI for row removal and duplication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6b0c5344832d991b76d228d9525e