### PR TITLE
Add CLI for activity reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Install dependencies and run the test suite:
 npm install
 npm test
 ```
+
+## Generating Activity Reports
+
+Use the `report.js` script to aggregate hours for all employees over a period.
+
+```bash
+node report.js --from 2025-09-01 --to 2025-09-30
+```
+
+Adjust the `--from` and `--to` dates to cover weekly, monthly or custom ranges. The script scans the `data` folder and prints hours per day for each worker.

--- a/__tests__/report.test.js
+++ b/__tests__/report.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { generateReport } = require('../report');
+
+test('generateReport aggregates hours within range', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pontaj-test-'));
+  const workerA = {
+    meta: { worker: 'Alice' },
+    rows: [
+      { date: '2025-09-01', start: '08:00', end: '16:00', nextDay: false, breakMin: 30 },
+      { date: '2025-09-05', start: '09:00', end: '17:00', nextDay: false, breakMin: 60 }
+    ]
+  };
+  const workerB = {
+    meta: { worker: 'Bob' },
+    rows: [
+      { date: '2025-09-02', start: '22:00', end: '02:00', nextDay: true, breakMin: 0 },
+      { date: '2025-10-01', start: '08:00', end: '12:00', nextDay: false, breakMin: 0 }
+    ]
+  };
+  fs.writeFileSync(path.join(tmpDir, 'pontaj_alice.json'), JSON.stringify(workerA));
+  fs.writeFileSync(path.join(tmpDir, 'pontaj_bob.json'), JSON.stringify(workerB));
+
+  const report = generateReport(tmpDir, '2025-09-01', '2025-09-30');
+  expect(report.Alice['2025-09-01']).toBeCloseTo(7.5); // 8h minus 30min break
+  expect(report.Alice['2025-09-05']).toBeCloseTo(7); // 8h minus 1h break
+  expect(report.Bob['2025-09-02']).toBeCloseTo(4); // Cross midnight shift
+  expect(report.Bob['2025-10-01']).toBeUndefined();
+});

--- a/report.js
+++ b/report.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseTime(str) {
+  const [h, m] = str.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function computeHours(row) {
+  if (!row.start || !row.end) return 0;
+  let start = parseTime(row.start);
+  let end = parseTime(row.end);
+  if (row.nextDay || end < start) {
+    end += 24 * 60;
+  }
+  const breakMin = row.breakMin || 0;
+  return Math.max(0, (end - start - breakMin) / 60);
+}
+
+function loadJson(file) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return data;
+}
+
+function generateReport(dataDir, fromDate, toDate) {
+  const from = fromDate ? new Date(fromDate) : null;
+  const to = toDate ? new Date(toDate) : null;
+  const report = {};
+  const files = fs.readdirSync(dataDir).filter(f => f.startsWith('pontaj_') && f.endsWith('.json'));
+  for (const file of files) {
+    const fullPath = path.join(dataDir, file);
+    const json = loadJson(fullPath);
+    const worker = json.meta?.worker || file;
+    for (const row of json.rows || []) {
+      if (!row.date) continue;
+      const dateObj = new Date(row.date);
+      if (from && dateObj < from) continue;
+      if (to && dateObj > to) continue;
+      const dateStr = row.date;
+      const hours = computeHours(row);
+      if (!report[worker]) report[worker] = {};
+      report[worker][dateStr] = (report[worker][dateStr] || 0) + hours;
+    }
+  }
+  return report;
+}
+
+function formatReport(rep) {
+  let out = '';
+  for (const worker of Object.keys(rep).sort()) {
+    out += `\n${worker}\n`;
+    const dates = Object.keys(rep[worker]).sort();
+    for (const d of dates) {
+      out += `  ${d}: ${rep[worker][d].toFixed(2)}h\n`;
+    }
+  }
+  return out.trim();
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const options = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      options[args[i].slice(2)] = args[i + 1];
+      i++;
+    }
+  }
+  const dataDir = options.dir || path.join(__dirname, 'data');
+  const rep = generateReport(dataDir, options.from, options.to);
+  console.log(formatReport(rep));
+}
+
+module.exports = { generateReport, formatReport };


### PR DESCRIPTION
## Summary
- document report generation usage in README
- add script to aggregate hours per employee between dates
- test report generation with cross-midnight shifts

## Testing
- `npm test`
- `node report.js --from 2025-09-01 --to 2025-09-30`


------
https://chatgpt.com/codex/tasks/task_e_68bd749d1b8c832d91aaa91729f409b1