### PR TITLE
Use commander for CLI argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ npm test
 
 ## Generating Activity Reports
 
-Use the `report.js` script to aggregate hours for all employees over a period.
+Use the `report.js` script to aggregate hours for all employees over a period. The `--from` and `--to` options are required; `--dir` defaults to the bundled `data` folder.
 
 ```bash
 node report.js --from 2025-09-01 --to 2025-09-30
 ```
 
-Adjust the `--from` and `--to` dates to cover weekly, monthly or custom ranges. The script scans the `data` folder and prints hours per day for each worker.
+Run `--help` to see all available options:
+
+```bash
+node report.js --help
+```
+
+Adjust the date range to cover weekly, monthly, or custom spans. The script scans the chosen directory and prints hours per day for each worker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "fisa-pontaj-campanie",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
       "devDependencies": {
         "jest": "^30.1.3"
       }
@@ -1892,6 +1895,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^30.1.3"
+  },
+  "dependencies": {
+    "commander": "^14.0.0"
   }
 }

--- a/report.js
+++ b/report.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { program } = require('commander');
 
 function parseTime(str) {
   const [h, m] = str.split(':').map(Number);
@@ -58,16 +59,15 @@ function formatReport(rep) {
 }
 
 if (require.main === module) {
-  const args = process.argv.slice(2);
-  const options = {};
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith('--')) {
-      options[args[i].slice(2)] = args[i + 1];
-      i++;
-    }
-  }
-  const dataDir = options.dir || path.join(__dirname, 'data');
-  const rep = generateReport(dataDir, options.from, options.to);
+  program
+    .requiredOption('--from <date>', 'start date (YYYY-MM-DD)')
+    .requiredOption('--to <date>', 'end date (YYYY-MM-DD)')
+    .option('--dir <path>', 'directory with timesheets', path.join(__dirname, 'data'));
+
+  program.parse(process.argv);
+
+  const { dir, from, to } = program.opts();
+  const rep = generateReport(dir, from, to);
   console.log(formatReport(rep));
 }
 


### PR DESCRIPTION
## Summary
- add `commander` dependency
- switch report.js argument parsing to `commander` with required date options and help
- document CLI usage and help in README

## Testing
- `npm test`
- `node report.js --help`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d6a2288832d873df26157152e6a