### PR TITLE
Use friendly fallback for worker names

### DIFF
--- a/__tests__/report.test.js
+++ b/__tests__/report.test.js
@@ -13,7 +13,6 @@ test('generateReport aggregates hours within range', () => {
     ]
   };
   const workerB = {
-    meta: { worker: 'Bob' },
     rows: [
       { date: '2025-09-02', start: '22:00', end: '02:00', nextDay: true, breakMin: 0 },
       { date: '2025-10-01', start: '08:00', end: '12:00', nextDay: false, breakMin: 0 }
@@ -25,6 +24,6 @@ test('generateReport aggregates hours within range', () => {
   const report = generateReport(tmpDir, '2025-09-01', '2025-09-30');
   expect(report.Alice['2025-09-01']).toBeCloseTo(7.5); // 8h minus 30min break
   expect(report.Alice['2025-09-05']).toBeCloseTo(7); // 8h minus 1h break
-  expect(report.Bob['2025-09-02']).toBeCloseTo(4); // Cross midnight shift
-  expect(report.Bob['2025-10-01']).toBeUndefined();
+  expect(report.bob['2025-09-02']).toBeCloseTo(4); // Cross midnight shift
+  expect(report.bob['2025-10-01']).toBeUndefined();
 });

--- a/report.js
+++ b/report.js
@@ -31,7 +31,7 @@ function generateReport(dataDir, fromDate, toDate) {
   for (const file of files) {
     const fullPath = path.join(dataDir, file);
     const json = loadJson(fullPath);
-    const worker = json.meta?.worker || file;
+    const worker = json.meta?.worker || path.basename(file, '.json').replace(/^pontaj_/, '');
     for (const row of json.rows || []) {
       if (!row.date) continue;
       const dateObj = new Date(row.date);


### PR DESCRIPTION
## Summary
- Strip `pontaj_` prefix and `.json` extension from fallback worker names in report generation
- Update tests for new filename-based worker naming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e347264832d922f12ec2dd90373