### PR TITLE
Validate CLI date inputs and add tests

### DIFF
--- a/__tests__/report-cli.test.js
+++ b/__tests__/report-cli.test.js
@@ -1,0 +1,32 @@
+const { execFileSync } = require('child_process');
+
+describe('report CLI argument validation', () => {
+  test('malformed dates cause errors', () => {
+    try {
+      execFileSync('node', ['report.js', '--from', 'bad', '--to', '2025-01-01'], { encoding: 'utf8' });
+      throw new Error('Expected command to fail');
+    } catch (err) {
+      expect(err.status).not.toBe(0);
+      expect(err.stderr).toMatch(/Invalid --from date/);
+    }
+
+    try {
+      execFileSync('node', ['report.js', '--from', '2025-01-01', '--to', 'bad'], { encoding: 'utf8' });
+      throw new Error('Expected command to fail');
+    } catch (err) {
+      expect(err.status).not.toBe(0);
+      expect(err.stderr).toMatch(/Invalid --to date/);
+    }
+  });
+
+  test('reversed date range causes error', () => {
+    try {
+      execFileSync('node', ['report.js', '--from', '2025-02-01', '--to', '2025-01-01'], { encoding: 'utf8' });
+      throw new Error('Expected command to fail');
+    } catch (err) {
+      expect(err.status).not.toBe(0);
+      expect(err.stderr).toMatch(/must be less than or equal/);
+    }
+  });
+});
+

--- a/report.js
+++ b/report.js
@@ -67,7 +67,25 @@ if (require.main === module) {
   program.parse(process.argv);
 
   const { dir, from, to } = program.opts();
-  const rep = generateReport(dir, from, to);
+
+  const fromDate = new Date(from);
+  if (isNaN(fromDate)) {
+    console.error(`Invalid --from date: ${from}`);
+    process.exit(1);
+  }
+
+  const toDate = new Date(to);
+  if (isNaN(toDate)) {
+    console.error(`Invalid --to date: ${to}`);
+    process.exit(1);
+  }
+
+  if (fromDate > toDate) {
+    console.error('--from date must be less than or equal to --to date');
+    process.exit(1);
+  }
+
+  const rep = generateReport(dir, fromDate, toDate);
   const formatted = formatReport(rep);
   if (formatted) {
     console.log(formatted);


### PR DESCRIPTION
## Summary
- Parse and validate CLI `--from` and `--to` dates, ensuring proper order before generating reports
- Add tests covering malformed dates and reversed ranges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd8428e39c832d8ecf8ae304ebfddc