### PR TITLE
Handle missing data directory gracefully

### DIFF
--- a/__tests__/report-cli.test.js
+++ b/__tests__/report-cli.test.js
@@ -1,4 +1,7 @@
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
 describe('report CLI argument validation', () => {
   test('malformed dates cause errors', () => {
@@ -26,6 +29,20 @@ describe('report CLI argument validation', () => {
     } catch (err) {
       expect(err.status).not.toBe(0);
       expect(err.stderr).toMatch(/must be less than or equal/);
+    }
+  });
+
+  test('missing data directory causes descriptive error', () => {
+    const missingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pontaj-missing-cli-'));
+    fs.rmSync(missingDir, { recursive: true, force: true });
+    try {
+      execFileSync('node', ['report.js', '--from', '2025-09-01', '--to', '2025-09-30', '--dir', missingDir], {
+        encoding: 'utf8'
+      });
+      throw new Error('Expected command to fail');
+    } catch (err) {
+      expect(err.status).not.toBe(0);
+      expect(err.stderr).toContain(`Data directory not found: ${missingDir}`);
     }
   });
 });

--- a/__tests__/report.test.js
+++ b/__tests__/report.test.js
@@ -67,3 +67,10 @@ test('CLI reports hours and shows no activity when appropriate', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test('generateReport throws descriptive error when directory missing', () => {
+  const missingDir = path.join(os.tmpdir(), 'pontaj-missing-test-');
+  fs.rmSync(missingDir, { recursive: true, force: true });
+  expect(() => generateReport(missingDir, '2025-01-01', '2025-01-02'))
+    .toThrow(`Data directory not found: ${missingDir}`);
+});

--- a/report.js
+++ b/report.js
@@ -27,7 +27,17 @@ function generateReport(dataDir, fromDate, toDate) {
   const from = fromDate ? new Date(fromDate) : null;
   const to = toDate ? new Date(toDate) : null;
   const report = {};
-  const files = fs.readdirSync(dataDir).filter(f => f.startsWith('pontaj_') && f.endsWith('.json'));
+  let files;
+  try {
+    files = fs
+      .readdirSync(dataDir)
+      .filter(f => f.startsWith('pontaj_') && f.endsWith('.json'));
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error(`Data directory not found: ${dataDir}`);
+    }
+    throw err;
+  }
   for (const file of files) {
     const fullPath = path.join(dataDir, file);
     const json = loadJson(fullPath);


### PR DESCRIPTION
## Summary
- guard `generateReport` against missing data directories and throw a helpful error
- add tests covering generateReport and CLI when directory does not exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd84b58270832d8a7b76329bc121a1