### PR TITLE
Document sample report output and clarify empty range message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ node report.js --help
 ```
 
 Adjust the date range to cover weekly, monthly, or custom spans. The script scans the chosen directory and prints hours per day for each worker.
+
+## Example output
+
+```
+Alice
+  2025-09-01: 7.50h
+  2025-09-05: 7.00h
+
+bob
+  2025-09-02: 4.00h
+```
+
+For date ranges without any activity, the script prints:
+
+```
+No activity found for selected period.
+```

--- a/__tests__/report.test.js
+++ b/__tests__/report.test.js
@@ -62,7 +62,7 @@ test('CLI reports hours and shows no activity when appropriate', () => {
     );
 
     const noActivity = execFileSync('node', ['report.js', '--from', '2025-08-01', '--to', '2025-08-31', '--dir', tmpDir], { encoding: 'utf8' }).trim();
-    expect(noActivity).toBe('No activity.');
+    expect(noActivity).toBe('No activity found for selected period.');
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/report.js
+++ b/report.js
@@ -100,7 +100,7 @@ if (require.main === module) {
   if (formatted) {
     console.log(formatted);
   } else {
-    console.log('No activity.');
+    console.log('No activity found for selected period.');
   }
 }
 


### PR DESCRIPTION
## Summary
- document sample CLI report output in README
- clarify empty range handling and mention `No activity found for selected period.`
- align tests with updated message

## Testing
- `node report.js --from 2025-09-01 --to 2025-09-30`
- `node report.js --from 2025-09-01 --to 2025-09-30 --dir "$tmpdir2"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8649361c832d9d95b53639ffebb8