### PR TITLE
feat: add client-side reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,23 @@
       </div>
     </div>
 
+    <div id="reportsModal" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-4 z-50 hidden no-print">
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-lg w-full p-6 sm:p-8" role="dialog" aria-modal="true" aria-labelledby="reports-title">
+        <div class="flex justify-between items-center mb-4">
+          <h2 id="reports-title" class="text-lg font-semibold">Rapoarte</h2>
+          <button id="closeReportsModal" class="text-gray-400 dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-100">&times;</button>
+        </div>
+        <div class="space-y-4">
+          <div class="flex gap-2">
+            <input id="reportFrom" type="date" class="focusable flex-1 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 border" />
+            <input id="reportTo" type="date" class="focusable flex-1 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 border" />
+            <button id="generateReportBtn" class="focusable bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 font-semibold">Generează</button>
+          </div>
+          <pre id="reportOutput" class="bg-gray-100 dark:bg-gray-900 p-4 rounded-lg overflow-auto max-h-96 text-sm"></pre>
+        </div>
+      </div>
+    </div>
+
     <section class="no-print mb-4 grid grid-cols-2 sm:grid-cols-3 lg:flex gap-2">
       <button id="addRow" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700">Adaugă rând</button>
       <button id="deleteSelected" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-rose-600 text-white hover:bg-rose-700">Șterge selectatele</button>
@@ -108,6 +125,7 @@
       <button id="printBtn" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-gray-700 text-white hover:bg-gray-800">Printează</button>
       <button id="resetData" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-yellow-500 text-white hover:bg-yellow-600">Resetează date</button>
       <button id="syncData" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-purple-600 text-white hover:bg-purple-700">Sincronizează</button>
+      <button id="viewReports" type="button" class="focusable inline-flex items-center justify-center px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700">Rapoarte</button>
     </section>
 
     <form id="timesheetForm" class="bg-white dark:bg-gray-800 rounded-xl shadow-md ring-1 ring-gray-200 dark:ring-gray-700 overflow-hidden">
@@ -200,7 +218,8 @@
   </tr>
 </template>
 
-  <script>
+  <script type="module">
+    import { generateReport, formatReport } from './report-client.js';
     document.addEventListener("DOMContentLoaded", () => {
       // --- State, Helpers & Elements ---
       const WORKERS = ["Prică Jenița", "Neagu Marian", "Banu Mitică", "Prică Emilian"];
@@ -216,7 +235,10 @@
         saveGithubConfig: document.getElementById("saveGithubConfig"), testConnection: document.getElementById("testConnection"),
         statusIndicator: document.getElementById("statusIndicator"), statusText: document.getElementById("statusText"),
         githubError: document.getElementById("githubError"), year: document.getElementById("year"),
-        themeToggle: document.getElementById("themeToggle"),
+        themeToggle: document.getElementById("themeToggle"), viewReports: document.getElementById("viewReports"),
+        reportsModal: document.getElementById("reportsModal"), closeReportsModal: document.getElementById("closeReportsModal"),
+        reportFrom: document.getElementById("reportFrom"), reportTo: document.getElementById("reportTo"),
+        generateReportBtn: document.getElementById("generateReportBtn"), reportOutput: document.getElementById("reportOutput"),
       };
       
       let githubConfig = { token: '', repo: '' };
@@ -474,6 +496,30 @@
         computeGrand();
         save();
       };
+
+      const runReport = async () => {
+        els.reportOutput.textContent = 'Se generează...';
+        const from = els.reportFrom.value;
+        const to = els.reportTo.value;
+        const timesheets = [];
+        for (const w of WORKERS) {
+          const path = `data/pontaj_${slug(w)}.json`;
+          let data = null;
+          try {
+            const res = await githubRequest(path);
+            data = JSON.parse(decodeURIComponent(escape(atob(res.content))));
+          } catch (e) {
+            const local = localStorage.getItem(`pontaj-v3.4-local-${slug(w)}`);
+            if (local) {
+              try { data = JSON.parse(local); } catch { data = null; }
+            }
+          }
+          if (data) timesheets.push(data);
+        }
+        const rep = generateReport(timesheets, from, to);
+        const formatted = formatReport(rep);
+        els.reportOutput.textContent = formatted || 'Nicio activitate pentru perioada selectată.';
+      };
       
       // --- Event Listeners & Init ---
       function setupEventListeners() {
@@ -516,6 +562,10 @@
         els.testConnection.addEventListener("click", testGitHubConnection);
 
         els.exportCSV.addEventListener("click", () => { /* Add export logic here if needed */ });
+
+        els.viewReports.addEventListener("click", () => els.reportsModal.classList.remove("hidden"));
+        els.closeReportsModal.addEventListener("click", () => els.reportsModal.classList.add("hidden"));
+        els.generateReportBtn.addEventListener("click", runReport);
 
         els.themeToggle.addEventListener("click", () => {
           document.documentElement.classList.toggle("dark");

--- a/report-client.js
+++ b/report-client.js
@@ -1,0 +1,48 @@
+export function parseTime(str) {
+  const [h, m] = (str || '0:0').split(':').map(Number);
+  return h * 60 + m;
+}
+
+export function computeHours(row) {
+  if (!row.start || !row.end) return 0;
+  let start = parseTime(row.start);
+  let end = parseTime(row.end);
+  if (row.nextDay || end < start) {
+    end += 24 * 60;
+  }
+  const breakMin = row.breakMin || 0;
+  return Math.max(0, (end - start - breakMin) / 60);
+}
+
+export function generateReport(timesheets = [], fromDate, toDate) {
+  const from = fromDate ? new Date(fromDate) : null;
+  const to = toDate ? new Date(toDate) : null;
+  const report = {};
+  for (const sheet of timesheets) {
+    const worker = sheet.meta?.worker || 'necunoscut';
+    for (const row of sheet.rows || []) {
+      if (!row.date) continue;
+      const dateObj = new Date(row.date);
+      if (from && dateObj < from) continue;
+      if (to && dateObj > to) continue;
+      const dateStr = row.date;
+      const hours = computeHours(row);
+      if (!report[worker]) report[worker] = {};
+      report[worker][dateStr] = (report[worker][dateStr] || 0) + hours;
+    }
+  }
+  return report;
+}
+
+export function formatReport(rep) {
+  let out = '';
+  const workers = Object.keys(rep).sort();
+  for (const worker of workers) {
+    out += `\n${worker}\n`;
+    const dates = Object.keys(rep[worker]).sort();
+    for (const d of dates) {
+      out += `  ${d}: ${rep[worker][d].toFixed(2)}h\n`;
+    }
+  }
+  return out.trim();
+}


### PR DESCRIPTION
## Summary
- add Rapoarte button and modal to index.html to view timesheet summaries
- implement browser-side report generator module mirroring server logic
- compute and display per-worker hours directly in the UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8807621c832d9e1cad77afbe2c88