### PR TITLE
Use EU date and 24h time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Adjust the date range to cover weekly, monthly, or custom spans. The script scan
 
 ```
 Alice
-  2025-09-01: 7.50h
-  2025-09-05: 7.00h
+  01/09/2025: 7.50h
+  05/09/2025: 7.00h
 
 bob
-  2025-09-02: 4.00h
+  02/09/2025: 4.00h
 ```
 
 For date ranges without any activity, the script prints:

--- a/__tests__/report.test.js
+++ b/__tests__/report.test.js
@@ -54,11 +54,11 @@ test('CLI reports hours and shows no activity when appropriate', () => {
     const out = execFileSync('node', ['report.js', '--from', '2025-09-01', '--to', '2025-09-30', '--dir', tmpDir], { encoding: 'utf8' }).trim();
     expect(out).toBe(
       ['Alice',
-       '  2025-09-01: 7.50h',
-       '  2025-09-05: 7.00h',
+       '  01/09/2025: 7.50h',
+       '  05/09/2025: 7.00h',
        '',
        'bob',
-       '  2025-09-02: 4.00h'].join('\n')
+       '  02/09/2025: 4.00h'].join('\n')
     );
 
     const noActivity = execFileSync('node', ['report.js', '--from', '2025-08-01', '--to', '2025-08-31', '--dir', tmpDir], { encoding: 'utf8' }).trim();

--- a/bazine.html
+++ b/bazine.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gestionare Vin</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </head>
 <body class="bg-gray-100 text-gray-800 p-4">
   <h1 class="text-2xl mb-4">Gestionare Vin</h1>
@@ -85,6 +87,20 @@ let bazine = JSON.parse(localStorage.getItem(STORAGE_KEYS.bazine) || '[]');
 let loturi = JSON.parse(localStorage.getItem(STORAGE_KEYS.loturi) || '[]');
 let operatii = JSON.parse(localStorage.getItem(STORAGE_KEYS.operatii) || '[]');
 
+function formatDateRO(str) {
+  return new Date(str).toLocaleDateString('ro-RO', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  }).replace(/\./g, '/');
+}
+
+flatpickr(document.getElementById('opData'), {
+  dateFormat: 'Y-m-d',
+  altInput: true,
+  altFormat: 'd/m/Y'
+});
+
 function save() {
   localStorage.setItem(STORAGE_KEYS.bazine, JSON.stringify(bazine));
   localStorage.setItem(STORAGE_KEYS.loturi, JSON.stringify(loturi));
@@ -129,7 +145,7 @@ function showHistoryBazin(id) {
   const ops = operatii.filter(o => o.bazinSursa === id || o.bazinDest === id);
   for (const o of ops) {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td class='border p-2'>${o.data}</td><td class='border p-2'>${o.tip}${o.tratament? ' - '+o.tratament:''}</td><td class='border p-2'>${o.volum}</td><td class='border p-2'>${o.lotId||''}</td><td class='border p-2'>${o.bazinSursa||''}</td><td class='border p-2'>${o.bazinDest||''}</td>`;
+    tr.innerHTML = `<td class='border p-2'>${formatDateRO(o.data)}</td><td class='border p-2'>${o.tip}${o.tratament? ' - '+o.tratament:''}</td><td class='border p-2'>${o.volum}</td><td class='border p-2'>${o.lotId||''}</td><td class='border p-2'>${o.bazinSursa||''}</td><td class='border p-2'>${o.bazinDest||''}</td>`;
     body.appendChild(tr);
   }
 }
@@ -143,7 +159,7 @@ function showHistoryLot(id) {
   const ops = operatii.filter(o => o.lotId === id);
   for (const o of ops) {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td class='border p-2'>${o.data}</td><td class='border p-2'>${o.tip}</td><td class='border p-2'>${o.volum}</td><td class='border p-2'>${o.bazinSursa||''}</td><td class='border p-2'>${o.bazinDest||''}</td><td class='border p-2'>${o.tratament||''}</td>`;
+    tr.innerHTML = `<td class='border p-2'>${formatDateRO(o.data)}</td><td class='border p-2'>${o.tip}</td><td class='border p-2'>${o.volum}</td><td class='border p-2'>${o.bazinSursa||''}</td><td class='border p-2'>${o.bazinDest||''}</td><td class='border p-2'>${o.tratament||''}</td>`;
     body.appendChild(tr);
   }
 }

--- a/index.html
+++ b/index.html
@@ -194,12 +194,12 @@
     <td class="px-3 py-2 align-top">
       <div class="flex items-center gap-2">
         <button type="button" class="start-stop focusable px-2 py-1 rounded bg-green-600 hover:bg-green-700 text-white text-xs font-semibold">Start</button>
-        <input type="time" step="60" class="row-start focusable block w-28 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" />
+        <input class="row-start focusable block w-28 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" />
       </div>
     </td>
     <td class="px-3 py-2 align-top">
       <div class="flex items-center gap-2">
-        <input type="time" step="60" class="row-end focusable block w-28 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" />
+        <input class="row-end focusable block w-28 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-2 py-1 border" />
         <label class="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300 select-none">
           <input type="checkbox" class="next-day-toggle focusable" />
           <span>Zi următoare</span>
@@ -244,10 +244,35 @@
       let githubConfig = { token: '', repo: '' };
       let saveTimeout = null;
 
+      flatpickr(els.reportFrom, {
+        dateFormat: "Y-m-d",
+        altInput: true,
+        altFormat: "d/m/Y"
+      });
+      flatpickr(els.reportTo, {
+        dateFormat: "Y-m-d",
+        altInput: true,
+        altFormat: "d/m/Y"
+      });
+
       const slug = s => (s || "").normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
       const currentWorker = () => els.workerSelect.value === "__custom" ? (els.workerName.value.trim() || "custom") : els.workerSelect.value;
       const getFileName = () => `data/pontaj_${slug(currentWorker())}.json`;
       const getLocalStorageKey = () => `pontaj-v3.4-local-${slug(currentWorker())}`;
+
+      const formatDateRO = date =>
+        date.toLocaleDateString('ro-RO', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric'
+        }).replace(/\./g, '/');
+      const formatTimeRO = date =>
+        date.toLocaleTimeString('ro-RO', {
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false
+        });
+      const formatDateTimeRO = date => `${formatDateRO(date)} ${formatTimeRO(date)}`;
 
       function updateStatus(status, msg) {
         els.statusIndicator.className = `status-indicator status-${status}`;
@@ -303,12 +328,12 @@
              // File doesn't exist, which is fine.
           }
           const payload = {
-            message: `Update: ${currentWorker()} – ${new Date().toLocaleString("ro-RO")}`,
+            message: `Update: ${currentWorker()} – ${formatDateTimeRO(new Date())}`,
             content,
             ...(sha ? { sha } : {}),
           };
           await githubRequest(path, { method: "PUT", body: JSON.stringify(payload) });
-          updateStatus("saved", `Sincronizat la ${new Date().toLocaleTimeString()}`);
+          updateStatus("saved", `Sincronizat la ${formatTimeRO(new Date())}`);
         } catch (e) {
           updateStatus("error", `Eroare GitHub: ${e.message}`);
         }
@@ -412,7 +437,7 @@
         if (!data || Object.keys(data).length === 0) {
           const lastRow = els.tableBody.querySelector("tr:last-child");
           if (lastRow) {
-            const lastEnd = lastRow.querySelectorAll('input[type="time"]')[1]?.value || "";
+            const lastEnd = lastRow.querySelector('.row-end')?.value || "";
             data = { start: lastEnd };
           }
         }
@@ -431,13 +456,28 @@
 
         flatpickr(date, {
           dateFormat: "Y-m-d",
+          altInput: true,
+          altFormat: "d/m/Y",
           defaultDate: data && data.date ? data.date : null,
           minDate: new Date(new Date().getFullYear(), 0, 1),
           maxDate: new Date(new Date().getFullYear(), 11, 31)
         });
+        flatpickr(start, {
+          enableTime: true,
+          noCalendar: true,
+          dateFormat: "H:i",
+          time_24hr: true,
+          defaultDate: data && data.start ? data.start : null
+        });
+        flatpickr(end, {
+          enableTime: true,
+          noCalendar: true,
+          dateFormat: "H:i",
+          time_24hr: true,
+          defaultDate: data && data.end ? data.end : null
+        });
 
         if (data) {
-          start.value = data.start || ""; end.value = data.end || "";
           breakMin.value = data.breakMin ?? 0; notes.value = data.notes || "";
           if (nextDay && typeof data.nextDay === "boolean") nextDay.checked = data.nextDay;
         }
@@ -458,7 +498,7 @@
               timer = null;
               const now = new Date();
               const t = now.toTimeString().slice(0,5);
-              end.value = t;
+              end._flatpickr.setDate(t, true, "H:i");
               startStopBtn.textContent = "Start";
               startStopBtn.classList.remove("bg-red-600", "hover:bg-red-700");
               startStopBtn.classList.add("bg-green-600", "hover:bg-green-700");
@@ -466,8 +506,8 @@
             } else {
               const now = new Date();
               const t = now.toTimeString().slice(0,5);
-              start.value = t;
-              end.value = t;
+              start._flatpickr.setDate(t, true, "H:i");
+              end._flatpickr.setDate(t, true, "H:i");
               startStopBtn.textContent = "Stop";
               startStopBtn.classList.remove("bg-green-600", "hover:bg-green-700");
               startStopBtn.classList.add("bg-red-600", "hover:bg-red-700");
@@ -475,7 +515,7 @@
               timer = setInterval(() => {
                 const now = new Date();
                 const tt = now.toTimeString().slice(0,5);
-                end.value = tt;
+                end._flatpickr.setDate(tt, true, "H:i");
                 recalc();
               }, 1000);
             }

--- a/report-client.js
+++ b/report-client.js
@@ -41,7 +41,12 @@ export function formatReport(rep) {
     out += `\n${worker}\n`;
     const dates = Object.keys(rep[worker]).sort();
     for (const d of dates) {
-      out += `  ${d}: ${rep[worker][d].toFixed(2)}h\n`;
+      const dateFmt = new Date(d).toLocaleDateString('ro-RO', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      }).replace(/\./g, '/');
+      out += `  ${dateFmt}: ${rep[worker][d].toFixed(2)}h\n`;
     }
   }
   return out.trim();

--- a/report.js
+++ b/report.js
@@ -62,7 +62,12 @@ function formatReport(rep) {
     out += `\n${worker}\n`;
     const dates = Object.keys(rep[worker]).sort();
     for (const d of dates) {
-      out += `  ${d}: ${rep[worker][d].toFixed(2)}h\n`;
+      const dateFmt = new Date(d).toLocaleDateString('ro-RO', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      }).replace(/\./g, '/');
+      out += `  ${dateFmt}: ${rep[worker][d].toFixed(2)}h\n`;
     }
   }
   return out.trim();


### PR DESCRIPTION
## Summary
- format UI dates as DD/MM/YYYY and show 24-hour times
- render bazine and report outputs with European date style
- document and test the new date formatting
- force timesheet row times to use Flatpickr 24h picker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6bba4ea10832db433a6b346d2f304